### PR TITLE
[YPT-03] - Adicionando criação e edição protetor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+BUSCA_CEP_URL="https://brasilapi.com.br/api/cep/v2/"
+

--- a/app/Common/Traits/HasUuid.php
+++ b/app/Common/Traits/HasUuid.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Common\Traits;
+
+use Illuminate\Support\Str;
+
+trait HasUuid
+{
+    /**
+     * Trait HasUuid
+     *
+     * This trait adds a UUID field to the model and automatically generates a UUID when a new model is created.
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            $model->uuid = Str::uuid()->toString();
+        });
+    }
+}

--- a/app/Docs/BaseDocumentation.php
+++ b/app/Docs/BaseDocumentation.php
@@ -21,7 +21,7 @@ namespace App\Docs;
  *      url="{scheme}://{host}:{port}",
  *       description="Servidor dinâmico",
  *       variables={
- * 
+ *
  *           @OA\ServerVariable(
  *               serverVariable="scheme",
  *               enum={"http", "https"},

--- a/app/Docs/BaseDocumentation.php
+++ b/app/Docs/BaseDocumentation.php
@@ -16,6 +16,7 @@ namespace App\Docs;
  *     @OA\Tag(name="Users", description="Gerenciamento de usuários"),
  *     @OA\Tag(name="Animals", description="Cadastro e controle de animais"),
  *     @OA\Tag(name="Citizens", description="Gerenciamento de cidadãos"),
+ *     @OA\Tag(name="Protectors", description="Gerenciamento de protetores"),
  *
  *      @OA\Server(
  *      url="{scheme}://{host}:{port}",

--- a/app/Docs/BaseDocumentation.php
+++ b/app/Docs/BaseDocumentation.php
@@ -15,12 +15,13 @@ namespace App\Docs;
  *     @OA\Tag(name="Enums", description="Consulta de enums disponíveis"),
  *     @OA\Tag(name="Users", description="Gerenciamento de usuários"),
  *     @OA\Tag(name="Animals", description="Cadastro e controle de animais"),
+ *     @OA\Tag(name="Citizens", description="Gerenciamento de cidadãos"),
  *
  *      @OA\Server(
  *      url="{scheme}://{host}:{port}",
  *       description="Servidor dinâmico",
  *       variables={
- *
+ * 
  *           @OA\ServerVariable(
  *               serverVariable="scheme",
  *               enum={"http", "https"},
@@ -37,6 +38,13 @@ namespace App\Docs;
  *           )
  *       }
  *  )
+ * )
+ *
+ * @OA\SecurityScheme(
+ *     securityScheme="bearerAuth",
+ *     type="http",
+ *     scheme="bearer",
+ *     bearerFormat="JWT"
  * )
  */
 class BaseDocumentation {}

--- a/app/Docs/Citizens/IndexDocumentation.php
+++ b/app/Docs/Citizens/IndexDocumentation.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Docs\Citizens;
+
+/**
+ * @OA\Get(
+ *     path="/api/citizen",
+ *     summary="Lista todos os cidadãos",
+ *     tags={"Citizens"},
+ *     security={{"bearerAuth": {}}},
+ *
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Lista de cidadãos retornada com sucesso",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *                 @OA\Items(
+ *                     @OA\Property(property="id", type="integer", example=1),
+ *                     @OA\Property(property="uuid", type="string", example="a3f4c9b2-1234-5678-9abc-9876543210ff"),
+ *                     @OA\Property(property="email", type="string", example="test@test.com"),
+ *                     @OA\Property(property="phone", type="string", example="(31) 8730-5567"),
+ *                     @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *                     @OA\Property(property="gender", type="string", example="male"),
+ *                     @OA\Property(property="special_permissions", type="integer", example=0),
+ *                     @OA\Property(property="can_report_abuse", type="integer", example=0),
+ *                     @OA\Property(property="can_mobile_castration", type="integer", example=0)
+ *                 )
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class IndexDocumentation {}

--- a/app/Docs/Citizens/ShowDocumentation.php
+++ b/app/Docs/Citizens/ShowDocumentation.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Docs\Citizens;
+
+/**
+ * @OA\Get(
+ *     path="/api/citizen/{uuid}",
+ *     summary="Exibe os detalhes de um cidadão",
+ *     tags={"Citizens"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="uuid",
+ *         in="path",
+ *         required=true,
+ *         description="UUID do cidadão",
+ *         @OA\Schema(type="string", example="e68023dc-f657-45b5-bded-62fc80b76036")
+ *     ),
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *     @OA\Parameter(
+ *         name="with[]",
+ *         in="query",
+ *         required=false,
+ *         description="Relações para carregar. Ex: address, company, tenant",
+ *         @OA\Schema(type="string", example="address")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Cidadão encontrado",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="uuid", type="integer", example="e68023dc-f657-45b5-bded-62fc80b76036"),
+ *                 @OA\Property(property="name", type="string", example="Paulo"),
+ *                 @OA\Property(property="document", type="string", example="12345678910"),
+ *                 @OA\Property(property="email", type="string", example="test@test.com"),
+ *                 @OA\Property(property="phone", type="string", example="(31) 98765-4321"),
+ *                 @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *                 @OA\Property(property="gender", type="string", example="male"),
+ *                 @OA\Property(property="status", type="integer", example=1),
+ *                 @OA\Property(
+ *                     property="address",
+ *                     type="object",
+ *                     @OA\Property(property="zipcode", type="string", example="35010-600"),
+ *                     @OA\Property(property="street", type="string", example="Rua Flores"),
+ *                     @OA\Property(property="number", type="string", example="123"),
+ *                     @OA\Property(property="neighborhood", type="string", example="Centro"),
+ *                     @OA\Property(property="city", type="string", example="Governador Valadares"),
+ *                     @OA\Property(property="state", type="string", example="MG")
+ *                 )
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class ShowDocumentation {}

--- a/app/Docs/Citizens/StoreDocumentation.php
+++ b/app/Docs/Citizens/StoreDocumentation.php
@@ -19,7 +19,7 @@ namespace App\Docs\Citizens;
  *     @OA\RequestBody(
  *         required=true,
  *         @OA\JsonContent(
- *             required={"name", "document", "email", "phone", "birth_date", "gender", "status", "address", "tenant_id", "company_id"},
+ *             required={"name", "document", "email", "phone", "birth_date", "gender", "status", "address", "tenant_id"},
  *
  *             @OA\Property(property="name", type="string", example="Paulo"),
  *             @OA\Property(property="document", type="string", example="12345678910"),
@@ -47,7 +47,6 @@ namespace App\Docs\Citizens;
  *             ),
  *
  *             @OA\Property(property="tenant_id", type="integer", example=1),
- *             @OA\Property(property="company_id", type="integer", example=1)
  *         )
  *     ),
  *

--- a/app/Docs/Citizens/StoreDocumentation.php
+++ b/app/Docs/Citizens/StoreDocumentation.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Docs\Citizens;
+
+/**
+ * @OA\Post(
+ *     path="/api/citizen",
+ *     summary="Cadastra um novo cidadão",
+ *     tags={"Citizens"},
+ *
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             required={"name", "document", "email", "phone", "birth_date", "gender", "status", "address", "tenant_id", "company_id"},
+ *
+ *             @OA\Property(property="name", type="string", example="Paulo"),
+ *             @OA\Property(property="document", type="string", example="12345678910"),
+ *             @OA\Property(property="email", type="string", example="test@test.comm"),
+ *             @OA\Property(property="phone", type="string", example="(31) 98765-4321"),
+ *             @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *             @OA\Property(property="gender", type="string", example="male"),
+ *             @OA\Property(property="special_permissions", type="integer", example=1),
+ *             @OA\Property(property="can_report_abuse", type="integer", example=1),
+ *             @OA\Property(property="can_mobile_castration", type="integer", example=1),
+ *             @OA\Property(property="status", type="integer", example=1),
+ *
+ *             @OA\Property(
+ *                 property="address",
+ *                 type="object",
+ *                 required={"type", "zipcode", "street", "number", "neighborhood", "city", "state"},
+ *                 @OA\Property(property="type", type="integer", example=0),
+ *                 @OA\Property(property="zipcode", type="string", example="35010-600"),
+ *                 @OA\Property(property="street", type="string", example="Rua Flores"),
+ *                 @OA\Property(property="number", type="string", example="123"),
+ *                 @OA\Property(property="complement", type="string", example="Apto 202"),
+ *                 @OA\Property(property="neighborhood", type="string", example="Centro"),
+ *                 @OA\Property(property="city", type="string", example="Governador Valadares"),
+ *                 @OA\Property(property="state", type="string", example="MG")
+ *             ),
+ *
+ *             @OA\Property(property="tenant_id", type="integer", example=1),
+ *             @OA\Property(property="company_id", type="integer", example=1)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Cidadão cadastrado com sucesso",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=201),
+ *             @OA\Property(property="data", type="object",
+ *                 @OA\Property(property="id", type="integer", example=10),
+ *                 @OA\Property(property="name", type="string", example="Paulo"),
+ *                 @OA\Property(property="document", type="string", example="12345678910"),
+ *                 @OA\Property(property="email", type="string", example="test@test.com")
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class StoreDocumentation {}
+

--- a/app/Docs/Citizens/UpdateDocumentation.php
+++ b/app/Docs/Citizens/UpdateDocumentation.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Docs\Citizens;
+
+/**
+ * @OA\Put(
+ *     path="/api/citizen/{uuid}",
+ *     summary="Atualiza os dados de um cidadão",
+ *     tags={"Citizens"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="uuid",
+ *         in="path",
+ *         required=true,
+ *         description="UUID do cidadão",
+ *         @OA\Schema(type="string", example="a3f4c9b2-1234-5678-9abc-9876543210ff")
+ *     ),
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             @OA\Property(property="email", type="string", example="test@test.com"),
+ *             @OA\Property(property="phone", type="string", example="(31) 8730-5567"),
+ *             @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *             @OA\Property(property="gender", type="string", example="male"),
+ *             @OA\Property(property="special_permissions", type="integer", example=0),
+ *             @OA\Property(property="can_report_abuse", type="integer", example=0),
+ *             @OA\Property(property="can_mobile_castration", type="integer", example=0)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Cidadão atualizado com sucesso",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="id", type="integer", example=1),
+ *                 @OA\Property(property="uuid", type="string", example="a3f4c9b2-1234-5678-9abc-9876543210ff"),
+ *                 @OA\Property(property="email", type="string", example="test@test.com"),
+ *                 @OA\Property(property="phone", type="string", example="(31) 8730-5567"),
+ *                 @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *                 @OA\Property(property="gender", type="string", example="male"),
+ *                 @OA\Property(property="special_permissions", type="integer", example=0),
+ *                 @OA\Property(property="can_report_abuse", type="integer", example=0),
+ *                 @OA\Property(property="can_mobile_castration", type="integer", example=0)
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class UpdateDocumentation {}

--- a/app/Docs/Protector/IndexDocumentation.php
+++ b/app/Docs/Protector/IndexDocumentation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Docs\Protector;
+
+/**
+ * @OA\Get(
+ *     path="/api/protector",
+ *     summary="Lista todos os protetores",
+ *     tags={"Protectors"},
+ *     security={{"bearerAuth": {}}},
+ *
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Lista de Protetores retornada com sucesso",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *                 @OA\Items(
+ *                     @OA\Property(property="id", type="integer", example=1),
+ *                     @OA\Property(property="uuid", type="string", example="a3f4c9b2-1234-5678-9abc-9876543210ff"),
+ *                     @OA\Property(property="email", type="string", example="test@test.com"),
+ *                     @OA\Property(property="phone", type="string", example="(31) 8730-5567"),
+ *                     @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *                     @OA\Property(property="gender", type="string", example="male"),
+ *                     @OA\Property(property="special_permissions", type="integer", example=0),
+ *                 )
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class IndexDocumentation {}

--- a/app/Docs/Protector/ShowDocumentation.php
+++ b/app/Docs/Protector/ShowDocumentation.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Docs\Protector;
+
+/**
+ * @OA\Get(
+ *     path="/api/protector/{uuid}",
+ *     summary="Exibe os detalhes de um protetor",
+ *     tags={"Protectors"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="uuid",
+ *         in="path",
+ *         required=true,
+ *         description="UUID do protetor",
+ *         @OA\Schema(type="string", example="e68023dc-f657-45b5-bded-62fc80b76036")
+ *     ),
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *     @OA\Parameter(
+ *         name="with[]",
+ *         in="query",
+ *         required=false,
+ *         description="Relações para carregar. Ex: address, company, tenant",
+ *         @OA\Schema(type="string", example="address")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Protetor encontrado",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="uuid", type="integer", example="e68023dc-f657-45b5-bded-62fc80b76036"),
+ *                 @OA\Property(property="name", type="string", example="Paulo"),
+ *                 @OA\Property(property="document", type="string", example="12345678910"),
+ *                 @OA\Property(property="email", type="string", example="test@test.com"),
+ *                 @OA\Property(property="phone", type="string", example="(31) 98765-4321"),
+ *                 @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *                 @OA\Property(property="gender", type="string", example="male"),
+ *                 @OA\Property(property="status", type="integer", example=1),
+ *                 @OA\Property(
+ *                     property="address",
+ *                     type="object",
+ *                     @OA\Property(property="zipcode", type="string", example="35010-600"),
+ *                     @OA\Property(property="street", type="string", example="Rua Flores"),
+ *                     @OA\Property(property="number", type="string", example="123"),
+ *                     @OA\Property(property="neighborhood", type="string", example="Centro"),
+ *                     @OA\Property(property="city", type="string", example="Governador Valadares"),
+ *                     @OA\Property(property="state", type="string", example="MG")
+ *                 )
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class ShowDocumentation {}

--- a/app/Docs/Protector/StoreDocumentation.php
+++ b/app/Docs/Protector/StoreDocumentation.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Docs\Protector;
+
+/**
+ * @OA\Post(
+ *     path="/api/protector",
+ *     summary="Cadastra um novo protetor",
+ *     tags={"Protectors"},
+ *
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             required={"name", "document", "email", "phone", "birth_date", "gender", "status", "address", "tenant_id"},
+ *
+ *             @OA\Property(property="name", type="string", example="Paulo"),
+ *             @OA\Property(property="document", type="string", example="12345678910"),
+ *             @OA\Property(property="email", type="string", example="test@test.comm"),
+ *             @OA\Property(property="phone", type="string", example="(31) 98765-4321"),
+ *             @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *             @OA\Property(property="gender", type="string", example="male"),
+ *             @OA\Property(property="special_permissions", type="integer", example=1),
+ *             @OA\Property(property="status", type="integer", example=1),
+ *
+ *             @OA\Property(
+ *                 property="address",
+ *                 type="object",
+ *                 required={"type", "zipcode", "street", "number", "neighborhood", "city", "state"},
+ *                 @OA\Property(property="type", type="integer", example=0),
+ *                 @OA\Property(property="zipcode", type="string", example="35010-600"),
+ *                 @OA\Property(property="street", type="string", example="Rua Flores"),
+ *                 @OA\Property(property="number", type="string", example="123"),
+ *                 @OA\Property(property="complement", type="string", example="Apto 202"),
+ *                 @OA\Property(property="neighborhood", type="string", example="Centro"),
+ *                 @OA\Property(property="city", type="string", example="Governador Valadares"),
+ *                 @OA\Property(property="state", type="string", example="MG")
+ *             ),
+ *
+ *             @OA\Property(property="tenant_id", type="integer", example=1),
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Protetor cadastrado com sucesso",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=201),
+ *             @OA\Property(property="data", type="object",
+ *                 @OA\Property(property="id", type="integer", example=10),
+ *                 @OA\Property(property="name", type="string", example="Paulo"),
+ *                 @OA\Property(property="document", type="string", example="12345678910"),
+ *                 @OA\Property(property="email", type="string", example="test@test.com")
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class StoreDocumentation {}
+

--- a/app/Docs/Protector/UpdateDocumentation.php
+++ b/app/Docs/Protector/UpdateDocumentation.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Docs\Protector;
+
+/**
+ * @OA\Put(
+ *     path="/api/protector/{uuid}",
+ *     summary="Atualiza os dados de um protetor",
+ *     tags={"Protectors"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="uuid",
+ *         in="path",
+ *         required=true,
+ *         description="UUID do Protetor",
+ *         @OA\Schema(type="string", example="a3f4c9b2-1234-5678-9abc-9876543210ff")
+ *     ),
+ *     @OA\Parameter(
+ *         name="X-Client-Type",
+ *         in="header",
+ *         required=true,
+ *         description="Tipo do cliente",
+ *         @OA\Schema(type="string", example="web")
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             @OA\Property(property="email", type="string", example="test@test.com"),
+ *             @OA\Property(property="phone", type="string", example="(31) 8730-5567"),
+ *             @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *             @OA\Property(property="gender", type="string", example="male"),
+ *             @OA\Property(property="special_permissions", type="integer", example=0),
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Protetor atualizado com sucesso",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="type", type="string", example="success"),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="id", type="integer", example=1),
+ *                 @OA\Property(property="uuid", type="string", example="a3f4c9b2-1234-5678-9abc-9876543210ff"),
+ *                 @OA\Property(property="email", type="string", example="test@test.com"),
+ *                 @OA\Property(property="phone", type="string", example="(31) 8730-5567"),
+ *                 @OA\Property(property="birth_date", type="string", format="date", example="1990-05-15"),
+ *                 @OA\Property(property="gender", type="string", example="male"),
+ *                 @OA\Property(property="special_permissions", type="integer", example=0),
+ *             ),
+ *             @OA\Property(property="show", type="boolean", example=true)
+ *         )
+ *     )
+ * )
+ */
+class UpdateDocumentation {}

--- a/app/Domains/Address/Entities/AddressEntity.php
+++ b/app/Domains/Address/Entities/AddressEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domains\Address\Entities;
+
+use App\Models\Address;
+
+class AddressEntity extends Address
+{
+    protected $table = "address";
+
+    protected $fillable = [
+        'type',
+        'zipcode',
+        'street',
+        'number',
+        'complement',
+        'neighborhood',
+        'city',
+        'state',
+    ];
+
+    public function addressable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Domains/Address/Repositories/AddressRepository.php
+++ b/app/Domains/Address/Repositories/AddressRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Domains\Address\Repositories;
+
+use App\Domains\Address\Entities\AddressEntity;
+use App\Domains\Abstracts\AbstractRepository;
+
+class AddressRepository extends AbstractRepository
+{
+    public function __construct(AddressEntity $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/Domains/Address/Services/AddressService.php
+++ b/app/Domains/Address/Services/AddressService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Domains\Address\Services;
+
+use App\Models\Address;
+use Illuminate\Support\Facades\Http;
+use App\Domains\Abstracts\AbstractService;
+use App\Domains\Address\Repositories\AddressRepository;
+
+class AddressService extends AbstractService
+{
+    /**
+     * Method __construct
+     *
+     *
+     * @return void
+     */
+    public function __construct(AddressRepository $addressRepository)
+    {
+        $this->repository = $addressRepository;
+    }
+
+    public function beforeSave(array $data): array
+    {
+        $data['cep'] = $this->onlyNumbers($data['cep']);
+        $data['city_code'] = $this->getCityCode($data['city'], $data['state']);
+
+        return $data;
+    }
+
+    public function onlyNumbers(string $value): string
+    {
+        return preg_replace('/\D/', '', $value);
+    }
+
+    public function beforeUpdate($id, array $data): array
+    {
+        $data['cep'] = $this->onlyNumbers($data['cep']);
+        $data['city_code'] = $this->getCityCode($data['city'], $data['state']);
+
+        return $data;
+    }
+
+    public function getCityCode(string $city, string $state): ?int
+    {
+        $city = Address::where('city', $city)
+            ->where('state', $state)
+            ->pluck('id')
+            ->first();
+
+        if ($city) {
+            return $city;
+        }
+
+        return null;
+    }
+}

--- a/app/Domains/Citizen/Entities/CitizenEntity.php
+++ b/app/Domains/Citizen/Entities/CitizenEntity.php
@@ -15,7 +15,6 @@ class CitizenEntity extends Citizen
     protected $fillable = [
         'user_id',
         'tenant_id',
-        'company_id',
         'name',
         'document',
         'email',

--- a/app/Domains/Citizen/Entities/CitizenEntity.php
+++ b/app/Domains/Citizen/Entities/CitizenEntity.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Domains\Citizen\Entities;
+
+use App\Models\User;
+use App\Models\Tenant;
+use App\Models\Address;
+use App\Models\Citizen;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CitizenEntity extends Citizen
+{
+    protected $table = "citizens";
+
+    protected $fillable = [
+        'user_id',
+        'tenant_id',
+        'company_id',
+        'name',
+        'document',
+        'email',
+        'phone',
+        'observations',
+        'birth_date',
+        'gender',
+        'special_permissions',
+        'can_report_abuse',
+        'can_mobile_castration',
+        'status',
+        'updated_by'
+    ];
+
+    protected $hidden = [
+        'user_id',
+        'updated_at',
+    ];
+
+    public function user(): BelongsTo
+    {
+       return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function addresses()
+    {
+        return $this->morphMany(Address::class, 'addressable');
+    }
+}

--- a/app/Domains/Citizen/Repositories/CitizenRepository.php
+++ b/app/Domains/Citizen/Repositories/CitizenRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Domains\Citizen\Repositories;
+
+use App\Domains\Citizen\Entities\CitizenEntity;
+use App\Domains\Abstracts\AbstractRepository;
+
+class CitizenRepository extends AbstractRepository
+{
+    public function __construct(CitizenEntity $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/Domains/Citizen/Services/CitizenService.php
+++ b/app/Domains/Citizen/Services/CitizenService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domains\Citizen\Services;
+
+use App\Enums\AddressTypeEnum;
+use Illuminate\Support\Facades\Auth;
+use App\Domains\Abstracts\AbstractService;
+use App\Domains\Citizen\Repositories\CitizenRepository;
+
+class CitizenService extends AbstractService
+{
+    public function __construct(CitizenRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function beforeUpdate($id, array $data): array
+    {
+        $data['updated_by'] =  Auth::user()?->id;
+
+        return $data;
+    }
+
+    public function afterSave($entity, array $params)
+    {
+        $addressData = data_get($params, 'address');
+        if (isset($addressData)) {
+            $addressData['type'] = AddressTypeEnum::MAIN;
+            
+            $entity->addresses()->create($addressData);
+        }
+    }
+}

--- a/app/Domains/Protector/Entities/ProtectorEntity.php
+++ b/app/Domains/Protector/Entities/ProtectorEntity.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Domains\Protector\Entities;
+
+use App\Models\User;
+use App\Models\Tenant;
+use App\Models\Address;
+use App\Models\Protector;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProtectorEntity extends Protector
+{
+    protected $table = "protectors";
+
+    protected $fillable = [
+        'tenant_id',
+        'uuid',
+        'name',
+        'document',
+        'email',
+        'phone',
+        'birth_date',
+        'gender',
+        'special_permissions',
+        'status',
+        'updated_by'
+    ];
+
+    protected $hidden = [
+        'user_id',
+        'updated_at',
+    ];
+
+    public function user(): BelongsTo
+    {
+       return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function addresses()
+    {
+        return $this->morphMany(Address::class, 'addressable');
+    }
+}

--- a/app/Domains/Protector/Repositories/ProtectorRepository.php
+++ b/app/Domains/Protector/Repositories/ProtectorRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Domains\Protector\Repositories;
+
+use App\Domains\Protector\Entities\ProtectorEntity;
+use App\Domains\Abstracts\AbstractRepository;
+
+class ProtectorRepository extends AbstractRepository
+{
+    public function __construct(ProtectorEntity $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/Domains/Protector/Services/ProtectorService.php
+++ b/app/Domains/Protector/Services/ProtectorService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domains\Protector\Services;
+
+use App\Enums\AddressTypeEnum;
+use Illuminate\Support\Facades\Auth;
+use App\Domains\Abstracts\AbstractService;
+use App\Domains\Protector\Repositories\ProtectorRepository;
+
+class ProtectorService extends AbstractService
+{
+    public function __construct(ProtectorRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function beforeUpdate($id, array $data): array
+    {
+        $data['updated_by'] =  Auth::user()?->id;
+
+        return $data;
+    }
+
+    public function afterSave($entity, array $params)
+    {
+        $addressData = data_get($params, 'address');
+        if (isset($addressData)) {
+            $addressData['type'] = AddressTypeEnum::MAIN;
+            
+            $entity->addresses()->create($addressData);
+        }
+    }
+}

--- a/app/Domains/User/Entities/UserEntity.php
+++ b/app/Domains/User/Entities/UserEntity.php
@@ -25,6 +25,6 @@ class UserEntity extends User
 
     public function status(): HasOne
     {
-        return $this->hasOne(UserStatusEntity::class, 'user_id', 'id')->latest();
+        return $this->hasOne(UserStatusEntity::class, 'user_id', 'id')->latest('created_at');
     }
 }

--- a/app/Enums/AddressTypeEnum.php
+++ b/app/Enums/AddressTypeEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum AddressTypeEnum: int
+{
+    /**
+     * Type of address.
+     */
+    case MAIN = 0;
+    case SECONDARY = 1;
+}

--- a/app/Enums/StatusProtectorEnum.php
+++ b/app/Enums/StatusProtectorEnum.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Enums;
+
+use App\Domains\Abstracts\EnumInterface;
+use App\Domains\Abstracts\EnumTrait;
+
+enum StatusProtectorEnum: string implements EnumInterface
+{
+    use EnumTrait;
+
+    case PENDING = 'pending';
+    case IN_ANALYSIS = 'in_analysis';
+    case APPROVED = 'approved';
+    case REFUSED = 'refused';
+
+    public static function translations(string $locale = 'en'): array
+    {
+        $locations = [
+            'en' => [
+                'PENDING' => 'Pending',
+                'IN_ANALYSIS' => 'In analysis',
+                'APPROVED' => 'Approved',
+                'REFUSED' => 'Refused',
+            ],
+            'es' => [
+                'PENDING' => 'Pendiente',
+                'IN_ANALYSIS' => 'En análisis',
+                'APPROVED' => 'Aprobado',
+                'REFUSED' => 'Rechazado',
+            ],
+            'pt_BR' => [
+                'PENDING' => 'Pendente',
+                'IN_ANALYSIS' => 'Em análise',
+                'APPROVED' => 'Aprovado',
+                'REFUSED' => 'Recusado',
+            ],
+        ];
+
+        return match ($locale) {
+            'pt_BR' => data_get($locations, 'pt_BR'),
+            'es' => data_get($locations, 'es'),
+            default => data_get($locations, 'en'),
+        };
+    }
+}

--- a/app/Http/Controllers/Address/AddressController.php
+++ b/app/Http/Controllers/Address/AddressController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Address;
+
+use App\Http\Requests\SearchCepRequest;
+use App\Http\Controllers\AbstractController;
+use Illuminate\Http\JsonResponse;
+use App\Domains\Address\Services\AddressService;
+use Illuminate\Support\Facades\Http;
+
+
+class AddressController extends AbstractController
+{
+    public function __construct(AddressService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function searchCep(SearchCepRequest $request): JsonResponse
+    {
+        $url = config('services.busca_cep.url').$request->cep;
+
+        try {
+            $response = Http::timeout(5)->get($url);
+
+            if ($response->failed()) {
+                return response()->json(['error' => 'CEP não encontrado'], 404);
+            }
+
+            return response()->json($response->json());
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Erro ao buscar o CEP'], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
-use App\Http\Requests\Auth\LoginRequest;
 use App\Models\User;
+use App\Models\UserStatus;
+use App\Enums\UserStatusEnum;
+use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Validation\ValidationException;
 
 class LoginController extends Controller
@@ -19,6 +21,14 @@ class LoginController extends Controller
         }
 
         $user = User::where('email', $request->email)->firstOrFail();
+        $userstatus = UserStatus::where('user_id',  $user?->id)->firstOrFail();
+
+        if ($userstatus->status != UserStatusEnum::ACTIVE->value) {
+            throw ValidationException::withMessages([
+                'email' => ['Sua conta está inativa. Entre em contato com o administrador.'],
+            ]);
+        }
+
         $clientType = $request->header('X-Client-Type', 'spa');
         $tokenName = $clientType === 'mobile' ? 'mobile_token' : 'spa_token';
         $expiresAt = now()->addMinutes(config('sanctum.expiration', 60));

--- a/app/Http/Controllers/Citizen/CitizenController.php
+++ b/app/Http/Controllers/Citizen/CitizenController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Citizen;
+
+use App\Http\Controllers\AbstractController;
+use App\Domains\Citizen\Services\CitizenService;
+use App\Http\Requests\Citizen\StoreCitizenRequest;
+use App\Http\Requests\Citizen\UpdateCitizenRequest;
+
+class CitizenController extends AbstractController
+{
+    public $requestValidate = StoreCitizenRequest::class;
+
+    public $requestValidateUpdate = UpdateCitizenRequest::class;
+
+    public function __construct(CitizenService $service)
+    {
+        $this->service = $service;
+    }
+}

--- a/app/Http/Controllers/Protector/ProtectorController.php
+++ b/app/Http/Controllers/Protector/ProtectorController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Protector;
+
+use App\Http\Controllers\AbstractController;
+use App\Domains\Protector\Services\ProtectorService;
+use App\Http\Requests\Protector\StoreProtectorRequest;
+use App\Http\Requests\Protector\UpdateProtectorRequest;
+
+
+class ProtectorController extends AbstractController
+{
+    public $requestValidate = StoreProtectorRequest::class;
+
+    public $requestValidateUpdate = UpdateProtectorRequest::class;
+
+    public function __construct(ProtectorService $service)
+    {
+        $this->service = $service;
+    }
+}

--- a/app/Http/Requests/Citizen/StoreCitizenRequest.php
+++ b/app/Http/Requests/Citizen/StoreCitizenRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Requests\Citizen;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCitizenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+            'document' => [
+                'required',
+                'string',
+                'max:11',
+                'min:11',
+            ],
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                'unique:citizens,email'
+            ],
+            'phone' => [
+                'required',
+                'string',
+                'max:20',
+            ],
+            'address' => [
+                'required',
+                'min:8',
+                'max:20',
+            ],
+            'tenant_id' => [
+                'nullable', 
+                'integer', 
+                'exists:tenants,id'
+            ],
+            'company_id' => [
+                'nullable', 
+                'integer', 
+                'exists:companies,id'
+            ],
+            'birth_date' => ['required', 'date'],
+            'gender' => ['required', 'string', 'max:20'],
+            'special_permissions' => ['required','boolean'],
+            'can_report_abuse' => ['required','boolean'],
+            'can_mobile_castration' => ['required','boolean'],
+            'status' => ['required', 'integer'],
+            'address' => ['required', 'array'],
+            'address.type' => ['required', 'integer'],
+            'address.zipcode' => ['required', 'string', 'max:10'],
+            'address.street' => ['required', 'string', 'max:255'],
+            'address.number' => ['required', 'string', 'max:20'],
+            'address.complement' => ['nullable', 'string', 'max:255'],
+            'address.neighborhood' => ['required', 'string', 'max:255'],
+            'address.city' => ['required', 'string', 'max:255'],
+            'address.state' => ['required', 'string', 'max:2'],
+        ];
+    }
+}

--- a/app/Http/Requests/Citizen/StoreCitizenRequest.php
+++ b/app/Http/Requests/Citizen/StoreCitizenRequest.php
@@ -44,20 +44,10 @@ class StoreCitizenRequest extends FormRequest
                 'string',
                 'max:20',
             ],
-            'address' => [
-                'required',
-                'min:8',
-                'max:20',
-            ],
             'tenant_id' => [
-                'nullable', 
+                'required', 
                 'integer', 
                 'exists:tenants,id'
-            ],
-            'company_id' => [
-                'nullable', 
-                'integer', 
-                'exists:companies,id'
             ],
             'birth_date' => ['required', 'date'],
             'gender' => ['required', 'string', 'max:20'],

--- a/app/Http/Requests/Citizen/UpdateCitizenRequest.php
+++ b/app/Http/Requests/Citizen/UpdateCitizenRequest.php
@@ -40,11 +40,6 @@ class UpdateCitizenRequest extends FormRequest
                 'string',
                 'max:20',
             ],
-            'address' => [
-                'nullable',
-                'min:8',
-                'max:20',
-            ],
             'tenant_id' => [
                 'nullable', 
                 'integer', 

--- a/app/Http/Requests/Citizen/UpdateCitizenRequest.php
+++ b/app/Http/Requests/Citizen/UpdateCitizenRequest.php
@@ -50,11 +50,6 @@ class UpdateCitizenRequest extends FormRequest
                 'integer', 
                 'exists:tenants,id'
             ],
-            'company_id' => [
-                'nullable', 
-                'integer', 
-                'exists:companies,id'
-            ],
             'birth_date' => ['nullable', 'date'],
             'gender' => ['nullable', 'string', 'max:20'],
             'special_permissions' => ['nullable','boolean'],

--- a/app/Http/Requests/Citizen/UpdateCitizenRequest.php
+++ b/app/Http/Requests/Citizen/UpdateCitizenRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Requests\Citizen;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCitizenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+        public function rules(): array
+    {
+        return [
+            'name' => [
+                'nullable',
+                'string',
+                'max:255',
+            ],
+            'document' => [
+                'nullable',
+                'string',
+                'max:11',
+                'min:11',
+            ],
+            'email' => [
+                'nullable',
+                'email',
+                'max:255',
+                'unique:citizens,email'
+            ],
+            'phone' => [
+                'nullable',
+                'string',
+                'max:20',
+            ],
+            'address' => [
+                'nullable',
+                'min:8',
+                'max:20',
+            ],
+            'tenant_id' => [
+                'nullable', 
+                'integer', 
+                'exists:tenants,id'
+            ],
+            'company_id' => [
+                'nullable', 
+                'integer', 
+                'exists:companies,id'
+            ],
+            'birth_date' => ['nullable', 'date'],
+            'gender' => ['nullable', 'string', 'max:20'],
+            'special_permissions' => ['nullable','boolean'],
+            'can_report_abuse' => ['nullable','boolean'],
+            'can_mobile_castration' => ['nullable','boolean'],
+            'status' => ['nullable', 'integer'],
+            'address' => ['nullable', 'array'],
+            'address.type' => ['nullable', 'integer'],
+            'address.zipcode' => ['nullable', 'string', 'max:10'],
+            'address.street' => ['nullable', 'string', 'max:255'],
+            'address.number' => ['nullable', 'string', 'max:20'],
+            'address.complement' => ['nullable', 'string', 'max:255'],
+            'address.neighborhood' => ['nullable', 'string', 'max:255'],
+            'address.city' => ['nullable', 'string', 'max:255'],
+            'address.state' => ['nullable', 'string', 'max:2'],
+        ];
+    }
+}

--- a/app/Http/Requests/Protector/StoreProtectorRequest.php
+++ b/app/Http/Requests/Protector/StoreProtectorRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests\Protector;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProtectorRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+            'document' => [
+                'required',
+                'string',
+                'max:11',
+                'min:11',
+            ],
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                'unique:citizens,email'
+            ],
+            'phone' => [
+                'required',
+                'string',
+                'max:20',
+            ],
+            'tenant_id' => [
+                'nullable', 
+                'integer', 
+                'exists:tenants,id'
+            ],
+            'status' => [
+                'required', 
+                'boolean', 
+            ],
+            'birth_date' => ['required', 'date'],
+            'gender' => ['required', 'string', 'max:20'],
+            'special_permissions' => ['required','integer'],
+            'address' => ['required', 'array'],
+            'address.type' => ['required', 'integer'],
+            'address.zipcode' => ['required', 'string', 'max:10'],
+            'address.street' => ['required', 'string', 'max:255'],
+            'address.number' => ['required', 'string', 'max:20'],
+            'address.complement' => ['nullable', 'string', 'max:255'],
+            'address.neighborhood' => ['required', 'string', 'max:255'],
+            'address.city' => ['required', 'string', 'max:255'],
+            'address.state' => ['required', 'string', 'max:2'],
+        ];
+    }
+}

--- a/app/Http/Requests/Protector/UpdateProtectorRequest.php
+++ b/app/Http/Requests/Protector/UpdateProtectorRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests\Protector;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProtectorRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'nullable',
+                'string',
+                'max:255',
+            ],
+            'document' => [
+                'nullable',
+                'string',
+                'max:11',
+                'min:11',
+            ],
+            'email' => [
+                'nullable',
+                'email',
+                'max:255',
+                'unique:citizens,email'
+            ],
+            'phone' => [
+                'nullable',
+                'string',
+                'max:20',
+            ],
+            'tenant_id' => [
+                'nullable', 
+                'integer', 
+                'exists:tenants,id'
+            ],
+            'status' => [
+                'nullable', 
+                'integer', 
+            ],
+            'birth_date' => ['nullable', 'date'],
+            'gender' => ['nullable', 'string', 'max:20'],
+            'special_permissions' => ['nullable','integer'],
+            'address' => ['nullable', 'array'],
+            'address.type' => ['nullable', 'integer'],
+            'address.zipcode' => ['nullable', 'string', 'max:10'],
+            'address.street' => ['nullable', 'string', 'max:255'],
+            'address.number' => ['nullable', 'string', 'max:20'],
+            'address.complement' => ['nullable', 'string', 'max:255'],
+            'address.neighborhood' => ['nullable', 'string', 'max:255'],
+            'address.city' => ['nullable', 'string', 'max:255'],
+            'address.state' => ['nullable', 'string', 'max:2'],
+        ];
+    }
+}

--- a/app/Http/Requests/SearchCepRequest.php
+++ b/app/Http/Requests/SearchCepRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchCepRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'cep' => 'required|digits:8',
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'cep' => preg_replace('/\D/', '', $this->cep),
+        ]);
+    }
+
+    public function messages(): array
+    {
+        return [
+            'cep.required' => 'O CEP é obrigatório.',
+            'cep.digits' => 'O CEP deve ter exatamente 8 dígitos numéricos.',
+        ];
+    }
+}

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Address extends Model
+{
+    /** @use HasFactory<\Database\Factories\AddressFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'type',
+        'zipcode',
+        'street',
+        'number',
+        'complement',
+        'neighborhood',
+        'city',
+        'state',
+    ];
+
+    public function addressable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Citizen.php
+++ b/app/Models/Citizen.php
@@ -15,7 +15,6 @@ class Citizen extends Model
         'hash',
         'user_id',
         'tenant_id',
-        'company_id',
         'name',
         'document',
         'email',

--- a/app/Models/Citizen.php
+++ b/app/Models/Citizen.php
@@ -2,11 +2,36 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Common\Traits\HasUuid;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Citizen extends Model
 {
     /** @use HasFactory<\Database\Factories\CitizenFactory> */
-    use HasFactory;
+    use HasFactory, HasUuid;
+
+    protected $fillable = [
+        'hash',
+        'user_id',
+        'tenant_id',
+        'company_id',
+        'name',
+        'document',
+        'email',
+        'phone',
+        'observations',
+        'birth_date',
+        'gender',
+        'special_permissions',
+        'can_report_abuse',
+        'can_mobile_castration',
+        'status',
+        'updated_by'
+    ];
+
+    public function addresses()
+    {
+        return $this->morphMany(Address::class, 'addressable');
+    }
 }

--- a/app/Models/Protector.php
+++ b/app/Models/Protector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use App\Common\Traits\HasUuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Protector extends Model
+{
+    /** @use HasFactory<\Database\Factories\ProtectorFactory> */
+    use HasFactory, HasUuid;
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'uuid',
+        'name',
+        'document',
+        'email',
+        'phone',
+        'birth_date',
+        'gender',
+        'special_permissions',
+        'status',
+        'updated_by'
+    ];
+
+    public function addresses()
+    {
+        return $this->morphMany(Address::class, 'addressable');
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -9,4 +9,6 @@ class Tenant extends Model
 {
     /** @use HasFactory<\Database\Factories\TenantFactory> */
     use HasFactory;
+
+    protected $table = "tenants";
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,12 +3,14 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Auth\Passwords\CanResetPassword;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use Illuminate\Notifications\Notifiable;
+use App\Domains\User\Entities\UserStatusEntity;
+use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {
@@ -54,5 +56,10 @@ class User extends Authenticatable
     public function guardName(): string
     {
         return 'api';
+    }
+
+    public function status(): HasOne
+    {
+        return $this->hasOne(UserStatusEntity::class, 'user_id', 'id')->latest('created_at');
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'busca_cep' => [
+        'url' => env('BUSCA_CEP_URL'),
+    ],
+
 ];

--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Citizen;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Address>
+ */
+class AddressFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'type' => 0,
+            'zipcode' => $this->faker->postcode(),
+            'street' => $this->faker->streetName(),
+            'number' => $this->faker->buildingNumber(),
+            'complement' => $this->faker->optional()->secondaryAddress(),
+            'neighborhood' => $this->faker->word(),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->stateAbbr(),
+            'addressable_id' => Citizen::first()?->id ?? Citizen::factory()->create(),
+            'addressable_type' => Citizen::class,
+        ];
+    }
+}

--- a/database/factories/ProtectorFactory.php
+++ b/database/factories/ProtectorFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Protector>
+ */
+class ProtectorFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -10,14 +10,17 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class TenantFactory extends Factory
 {
     /**
-     * Define the model's default state.
+     * Define the model's default state.å
      *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
-            //
+            'user_name' => $this->faker->name(),
+            'user_email' => $this->faker->unique()->safeEmail(),
+            'company_name' => $this->faker->company(),
+            'status' => $this->faker->randomElement([0, 1]),
         ];
     }
 }

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class TenantFactory extends Factory
 {
     /**
-     * Define the model's default state.å
+     * Define the model's default state.
      *
      * @return array<string, mixed>
      */

--- a/database/migrations/2025_05_01_184047_create_citizens_table.php
+++ b/database/migrations/2025_05_01_184047_create_citizens_table.php
@@ -16,12 +16,11 @@ return new class extends Migration
             $table->string('hash')->nullable()->unique()->index();
             $table->string('uuid')->nullable()->unique();
             $table->foreignId('tenant_id')->constrained()->onDelete('cascade');
-            $table->foreignId('company_id')->constrained()->onDelete('cascade');
 
             $table->string('name');
             $table->string('email')->unique()->index();
             $table->string('document')->unique()->index();
-            $table->string('phone')->nullable();      
+            $table->string('phone')->nullable();
             $table->text('observations')->nullable();
             $table->foreignId('updated_by')->nullable()->constrained('users');
 

--- a/database/migrations/2025_05_01_184047_create_citizens_table.php
+++ b/database/migrations/2025_05_01_184047_create_citizens_table.php
@@ -14,14 +14,16 @@ return new class extends Migration
         Schema::create('citizens', function (Blueprint $table) {
             $table->id();
             $table->string('hash')->nullable()->unique()->index();
+            $table->string('uuid')->nullable()->unique();
             $table->foreignId('tenant_id')->constrained()->onDelete('cascade');
             $table->foreignId('company_id')->constrained()->onDelete('cascade');
 
             $table->string('name');
             $table->string('email')->unique()->index();
             $table->string('document')->unique()->index();
-            $table->string('phone')->nullable();
+            $table->string('phone')->nullable();      
             $table->text('observations')->nullable();
+            $table->foreignId('updated_by')->nullable()->constrained('users');
 
             $table->timestamps();
         });

--- a/database/migrations/2025_08_29_164645_create_addresses_table.php
+++ b/database/migrations/2025_08_29_164645_create_addresses_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('addresses', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->morphs('addressable');
+            $table->integer('type');
+            $table->string('zipcode');
+            $table->string('street');
+            $table->string('number');
+            $table->string('complement');
+            $table->string('neighborhood');
+            $table->string('city');
+            $table->string('state');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('addresses');
+    }
+};

--- a/database/migrations/2025_08_30_041319_add_extra_fields_to_citizens_table.php
+++ b/database/migrations/2025_08_30_041319_add_extra_fields_to_citizens_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('citizens', function (Blueprint $table) {
+            $table->date('birth_date')->nullable();
+            $table->string('gender', 10);
+            $table->boolean('special_permissions');
+            $table->boolean('can_report_abuse');
+            $table->boolean('can_mobile_castration');
+            $table->boolean('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('citizens', function (Blueprint $table) {
+            $table->dropColumn([
+                'birth_date',
+                'gender',
+                'special_permissions',
+                'can_report_abuse',
+                'can_mobile_castration',
+                'status',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_08_30_041319_add_extra_fields_to_citizens_table.php
+++ b/database/migrations/2025_08_30_041319_add_extra_fields_to_citizens_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->boolean('can_report_abuse');
             $table->boolean('can_mobile_castration');
             $table->boolean('status');
+            $table->integer('user_id');
         });
     }
 

--- a/database/migrations/2025_08_30_233938_create_protectors_table.php
+++ b/database/migrations/2025_08_30_233938_create_protectors_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('protectors', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('uuid')->nullable()->unique();
+            $table->foreignId('tenant_id')->constrained()->onDelete('cascade'); 
+            $table->string('name');
+            $table->string('document')->unique()->index();
+            $table->string('email')->unique()->index();
+            $table->string('phone')->nullable();     
+            $table->date('birth_date')->nullable();
+            $table->string('gender')->nullable();
+            $table->integer('special_permissions')->nullable();
+            $table->boolean('status');
+            $table->integer('pet_status')->nullable();   
+            $table->foreignId('updated_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('protectors');
+    }
+};

--- a/database/seeders/AddressSeeder.php
+++ b/database/seeders/AddressSeeder.php
@@ -2,16 +2,16 @@
 
 namespace Database\Seeders;
 
-use App\Models\Tenant;
+use App\Models\Address;
 use Illuminate\Database\Seeder;
 
-class TenantSeeder extends Seeder
+class AddressSeeder extends Seeder
 {
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        Tenant::factory()->create();
+        Address::factory()->create();
     }
 }

--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Company;
 use Illuminate\Database\Seeder;
 
 class CompanySeeder extends Seeder
@@ -11,6 +12,6 @@ class CompanySeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        Company::factory()->create();
     }
 }

--- a/database/seeders/ProtectorSeeder.php
+++ b/database/seeders/ProtectorSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Protector;
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class ProtectorSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Protector::factory()->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Citizen\CitizenController;
 use App\Http\Controllers\User\UserProfileController;
 use App\Http\Controllers\Auth\ResetPasswordController;
 use App\Http\Controllers\Auth\ForgotPasswordController;
+use App\Http\Controllers\Protector\ProtectorController;
 
 // Public authentication routes
 Route::group(['prefix' => 'auth'], function () {
@@ -34,11 +35,16 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('users', UserController::class);
     Route::apiResource('animals', AnimalController::class);
     Route::get('enums/{enum}', [EnumController::class, 'show']);
-
     Route::get('citizen', [CitizenController::class, 'index']);
     Route::get('citizen/{uuid}', [CitizenController::class, 'show']);
     Route::put('/citizen/{uuid}', [CitizenController::class, 'update']);
+
+    Route::get('protector', [ProtectorController::class, 'index']);
+    Route::get('protector/{uuid}', [ProtectorController::class, 'show']);
+    Route::put('/protector/{uuid}', [ProtectorController::class, 'update']);
+    
 });
 
+Route::post('protector', [ProtectorController::class, 'store']);
 Route::post('citizen', [CitizenController::class, 'store']);
 Route::get('busca/cep/{cep}', [AddressController::class, 'searchCep']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,15 +1,17 @@
 <?php
 
-use App\Http\Controllers\Animal\AnimalController;
-use App\Http\Controllers\Auth\ForgotPasswordController;
-use App\Http\Controllers\Auth\LoginController;
-use App\Http\Controllers\Auth\LogoutController;
-use App\Http\Controllers\Auth\RegisterController;
-use App\Http\Controllers\Auth\ResetPasswordController;
+use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\EnumController;
 use App\Http\Controllers\User\UserController;
+use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\LogoutController;
+use App\Http\Controllers\Animal\AnimalController;
+use App\Http\Controllers\Auth\RegisterController;
+use App\Http\Controllers\Address\AddressController;
+use App\Http\Controllers\Citizen\CitizenController;
 use App\Http\Controllers\User\UserProfileController;
-use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Auth\ResetPasswordController;
+use App\Http\Controllers\Auth\ForgotPasswordController;
 
 // Public authentication routes
 Route::group(['prefix' => 'auth'], function () {
@@ -32,4 +34,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('users', UserController::class);
     Route::apiResource('animals', AnimalController::class);
     Route::get('enums/{enum}', [EnumController::class, 'show']);
+    Route::put('/citizen/{uuid}', [CitizenController::class, 'update']);
 });
+
+Route::apiResource('citizen', CitizenController::class)->except(['update']);
+Route::get('busca/cep/{cep}', [AddressController::class, 'searchCep']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,8 +34,11 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('users', UserController::class);
     Route::apiResource('animals', AnimalController::class);
     Route::get('enums/{enum}', [EnumController::class, 'show']);
+
+    Route::get('citizen', [CitizenController::class, 'index']);
+    Route::get('citizen/{uuid}', [CitizenController::class, 'show']);
     Route::put('/citizen/{uuid}', [CitizenController::class, 'update']);
 });
 
-Route::apiResource('citizen', CitizenController::class)->except(['update']);
+Route::post('citizen', [CitizenController::class, 'store']);
 Route::get('busca/cep/{cep}', [AddressController::class, 'searchCep']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1061,16 +1061,6 @@
                 "operationId": "90afb54a8928ad20455273dea593f367",
                 "parameters": [
                     {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "Token JWT",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "example": "Bearer eyJ..."
-                        }
-                    },
-                    {
                         "name": "X-Client-Type",
                         "in": "header",
                         "description": "Tipo do cliente",
@@ -1095,8 +1085,7 @@
                                     "gender",
                                     "status",
                                     "address",
-                                    "tenant_id",
-                                    "company_id"
+                                    "tenant_id"
                                 ],
                                 "properties": {
                                     "name": {
@@ -1187,10 +1176,6 @@
                                         "type": "object"
                                     },
                                     "tenant_id": {
-                                        "type": "integer",
-                                        "example": 1
-                                    },
-                                    "company_id": {
                                         "type": "integer",
                                         "example": 1
                                     }
@@ -1624,6 +1609,533 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/protector": {
+            "get": {
+                "tags": [
+                    "Protectors"
+                ],
+                "summary": "Lista todos os protetores",
+                "operationId": "1f941c9b080615c961fcb8c20b8bb969",
+                "parameters": [
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista de Protetores retornada com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "example": 1
+                                                    },
+                                                    "uuid": {
+                                                        "type": "string",
+                                                        "example": "a3f4c9b2-1234-5678-9abc-9876543210ff"
+                                                    },
+                                                    "email": {
+                                                        "type": "string",
+                                                        "example": "test@test.com"
+                                                    },
+                                                    "phone": {
+                                                        "type": "string",
+                                                        "example": "(31) 8730-5567"
+                                                    },
+                                                    "birth_date": {
+                                                        "type": "string",
+                                                        "format": "date",
+                                                        "example": "1990-05-15"
+                                                    },
+                                                    "gender": {
+                                                        "type": "string",
+                                                        "example": "male"
+                                                    },
+                                                    "special_permissions": {
+                                                        "type": "integer",
+                                                        "example": 0
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Protectors"
+                ],
+                "summary": "Cadastra um novo protetor",
+                "operationId": "579a0066ce311c917200db1b77f483dd",
+                "parameters": [
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "document",
+                                    "email",
+                                    "phone",
+                                    "birth_date",
+                                    "gender",
+                                    "status",
+                                    "address",
+                                    "tenant_id"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Paulo"
+                                    },
+                                    "document": {
+                                        "type": "string",
+                                        "example": "12345678910"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "example": "test@test.comm"
+                                    },
+                                    "phone": {
+                                        "type": "string",
+                                        "example": "(31) 98765-4321"
+                                    },
+                                    "birth_date": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "1990-05-15"
+                                    },
+                                    "gender": {
+                                        "type": "string",
+                                        "example": "male"
+                                    },
+                                    "special_permissions": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "status": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "address": {
+                                        "required": [
+                                            "type",
+                                            "zipcode",
+                                            "street",
+                                            "number",
+                                            "neighborhood",
+                                            "city",
+                                            "state"
+                                        ],
+                                        "properties": {
+                                            "type": {
+                                                "type": "integer",
+                                                "example": 0
+                                            },
+                                            "zipcode": {
+                                                "type": "string",
+                                                "example": "35010-600"
+                                            },
+                                            "street": {
+                                                "type": "string",
+                                                "example": "Rua Flores"
+                                            },
+                                            "number": {
+                                                "type": "string",
+                                                "example": "123"
+                                            },
+                                            "complement": {
+                                                "type": "string",
+                                                "example": "Apto 202"
+                                            },
+                                            "neighborhood": {
+                                                "type": "string",
+                                                "example": "Centro"
+                                            },
+                                            "city": {
+                                                "type": "string",
+                                                "example": "Governador Valadares"
+                                            },
+                                            "state": {
+                                                "type": "string",
+                                                "example": "MG"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "tenant_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Protetor cadastrado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 201
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Paulo"
+                                                },
+                                                "document": {
+                                                    "type": "string",
+                                                    "example": "12345678910"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "test@test.com"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/protector/{uuid}": {
+            "get": {
+                "tags": [
+                    "Protectors"
+                ],
+                "summary": "Exibe os detalhes de um protetor",
+                "operationId": "871353d7003edb503d06b6a603220cd5",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID do protetor",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "e68023dc-f657-45b5-bded-62fc80b76036"
+                        }
+                    },
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    },
+                    {
+                        "name": "with[]",
+                        "in": "query",
+                        "description": "Relações para carregar. Ex: address, company, tenant",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "address"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Protetor encontrado",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "uuid": {
+                                                    "type": "integer",
+                                                    "example": "e68023dc-f657-45b5-bded-62fc80b76036"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Paulo"
+                                                },
+                                                "document": {
+                                                    "type": "string",
+                                                    "example": "12345678910"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "test@test.com"
+                                                },
+                                                "phone": {
+                                                    "type": "string",
+                                                    "example": "(31) 98765-4321"
+                                                },
+                                                "birth_date": {
+                                                    "type": "string",
+                                                    "format": "date",
+                                                    "example": "1990-05-15"
+                                                },
+                                                "gender": {
+                                                    "type": "string",
+                                                    "example": "male"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "address": {
+                                                    "properties": {
+                                                        "zipcode": {
+                                                            "type": "string",
+                                                            "example": "35010-600"
+                                                        },
+                                                        "street": {
+                                                            "type": "string",
+                                                            "example": "Rua Flores"
+                                                        },
+                                                        "number": {
+                                                            "type": "string",
+                                                            "example": "123"
+                                                        },
+                                                        "neighborhood": {
+                                                            "type": "string",
+                                                            "example": "Centro"
+                                                        },
+                                                        "city": {
+                                                            "type": "string",
+                                                            "example": "Governador Valadares"
+                                                        },
+                                                        "state": {
+                                                            "type": "string",
+                                                            "example": "MG"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Protectors"
+                ],
+                "summary": "Atualiza os dados de um protetor",
+                "operationId": "c74793b1bee53abb43bf58e94c0be6ac",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID do Protetor",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "a3f4c9b2-1234-5678-9abc-9876543210ff"
+                        }
+                    },
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "example": "test@test.com"
+                                    },
+                                    "phone": {
+                                        "type": "string",
+                                        "example": "(31) 8730-5567"
+                                    },
+                                    "birth_date": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "1990-05-15"
+                                    },
+                                    "gender": {
+                                        "type": "string",
+                                        "example": "male"
+                                    },
+                                    "special_permissions": {
+                                        "type": "integer",
+                                        "example": 0
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Protetor atualizado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "uuid": {
+                                                    "type": "string",
+                                                    "example": "a3f4c9b2-1234-5678-9abc-9876543210ff"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "test@test.com"
+                                                },
+                                                "phone": {
+                                                    "type": "string",
+                                                    "example": "(31) 8730-5567"
+                                                },
+                                                "birth_date": {
+                                                    "type": "string",
+                                                    "format": "date",
+                                                    "example": "1990-05-15"
+                                                },
+                                                "gender": {
+                                                    "type": "string",
+                                                    "example": "male"
+                                                },
+                                                "special_permissions": {
+                                                    "type": "integer",
+                                                    "example": 0
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
             }
         },
         "/api/users": {
@@ -2148,6 +2660,10 @@
         {
             "name": "Citizens",
             "description": "Gerenciamento de cidadãos"
+        },
+        {
+            "name": "Protectors",
+            "description": "Gerenciamento de protetores"
         }
     ]
 }

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -957,6 +957,580 @@
                 }
             }
         },
+        "/api/citizen": {
+            "get": {
+                "tags": [
+                    "Citizens"
+                ],
+                "summary": "Lista todos os cidadãos",
+                "operationId": "f34597ca12faa803f68023f857cdc3f2",
+                "parameters": [
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista de cidadãos retornada com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "example": 1
+                                                    },
+                                                    "uuid": {
+                                                        "type": "string",
+                                                        "example": "a3f4c9b2-1234-5678-9abc-9876543210ff"
+                                                    },
+                                                    "email": {
+                                                        "type": "string",
+                                                        "example": "test@test.com"
+                                                    },
+                                                    "phone": {
+                                                        "type": "string",
+                                                        "example": "(31) 8730-5567"
+                                                    },
+                                                    "birth_date": {
+                                                        "type": "string",
+                                                        "format": "date",
+                                                        "example": "1990-05-15"
+                                                    },
+                                                    "gender": {
+                                                        "type": "string",
+                                                        "example": "male"
+                                                    },
+                                                    "special_permissions": {
+                                                        "type": "integer",
+                                                        "example": 0
+                                                    },
+                                                    "can_report_abuse": {
+                                                        "type": "integer",
+                                                        "example": 0
+                                                    },
+                                                    "can_mobile_castration": {
+                                                        "type": "integer",
+                                                        "example": 0
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Citizens"
+                ],
+                "summary": "Cadastra um novo cidadão",
+                "operationId": "90afb54a8928ad20455273dea593f367",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "description": "Token JWT",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "Bearer eyJ..."
+                        }
+                    },
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "document",
+                                    "email",
+                                    "phone",
+                                    "birth_date",
+                                    "gender",
+                                    "status",
+                                    "address",
+                                    "tenant_id",
+                                    "company_id"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Paulo"
+                                    },
+                                    "document": {
+                                        "type": "string",
+                                        "example": "12345678910"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "example": "test@test.comm"
+                                    },
+                                    "phone": {
+                                        "type": "string",
+                                        "example": "(31) 98765-4321"
+                                    },
+                                    "birth_date": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "1990-05-15"
+                                    },
+                                    "gender": {
+                                        "type": "string",
+                                        "example": "male"
+                                    },
+                                    "special_permissions": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "can_report_abuse": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "can_mobile_castration": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "status": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "address": {
+                                        "required": [
+                                            "type",
+                                            "zipcode",
+                                            "street",
+                                            "number",
+                                            "neighborhood",
+                                            "city",
+                                            "state"
+                                        ],
+                                        "properties": {
+                                            "type": {
+                                                "type": "integer",
+                                                "example": 0
+                                            },
+                                            "zipcode": {
+                                                "type": "string",
+                                                "example": "35010-600"
+                                            },
+                                            "street": {
+                                                "type": "string",
+                                                "example": "Rua Flores"
+                                            },
+                                            "number": {
+                                                "type": "string",
+                                                "example": "123"
+                                            },
+                                            "complement": {
+                                                "type": "string",
+                                                "example": "Apto 202"
+                                            },
+                                            "neighborhood": {
+                                                "type": "string",
+                                                "example": "Centro"
+                                            },
+                                            "city": {
+                                                "type": "string",
+                                                "example": "Governador Valadares"
+                                            },
+                                            "state": {
+                                                "type": "string",
+                                                "example": "MG"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "tenant_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "company_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Cidadão cadastrado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 201
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Paulo"
+                                                },
+                                                "document": {
+                                                    "type": "string",
+                                                    "example": "12345678910"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "test@test.com"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/citizen/{uuid}": {
+            "get": {
+                "tags": [
+                    "Citizens"
+                ],
+                "summary": "Exibe os detalhes de um cidadão",
+                "operationId": "47eb1cf183ac07b99d4bba597edf2d34",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID do cidadão",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "e68023dc-f657-45b5-bded-62fc80b76036"
+                        }
+                    },
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    },
+                    {
+                        "name": "with[]",
+                        "in": "query",
+                        "description": "Relações para carregar. Ex: address, company, tenant",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "address"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Cidadão encontrado",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "uuid": {
+                                                    "type": "integer",
+                                                    "example": "e68023dc-f657-45b5-bded-62fc80b76036"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Paulo"
+                                                },
+                                                "document": {
+                                                    "type": "string",
+                                                    "example": "12345678910"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "test@test.com"
+                                                },
+                                                "phone": {
+                                                    "type": "string",
+                                                    "example": "(31) 98765-4321"
+                                                },
+                                                "birth_date": {
+                                                    "type": "string",
+                                                    "format": "date",
+                                                    "example": "1990-05-15"
+                                                },
+                                                "gender": {
+                                                    "type": "string",
+                                                    "example": "male"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "address": {
+                                                    "properties": {
+                                                        "zipcode": {
+                                                            "type": "string",
+                                                            "example": "35010-600"
+                                                        },
+                                                        "street": {
+                                                            "type": "string",
+                                                            "example": "Rua Flores"
+                                                        },
+                                                        "number": {
+                                                            "type": "string",
+                                                            "example": "123"
+                                                        },
+                                                        "neighborhood": {
+                                                            "type": "string",
+                                                            "example": "Centro"
+                                                        },
+                                                        "city": {
+                                                            "type": "string",
+                                                            "example": "Governador Valadares"
+                                                        },
+                                                        "state": {
+                                                            "type": "string",
+                                                            "example": "MG"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Citizens"
+                ],
+                "summary": "Atualiza os dados de um cidadão",
+                "operationId": "62655ceeee8f154388257869bff951cc",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID do cidadão",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "a3f4c9b2-1234-5678-9abc-9876543210ff"
+                        }
+                    },
+                    {
+                        "name": "X-Client-Type",
+                        "in": "header",
+                        "description": "Tipo do cliente",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "web"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "example": "test@test.com"
+                                    },
+                                    "phone": {
+                                        "type": "string",
+                                        "example": "(31) 8730-5567"
+                                    },
+                                    "birth_date": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "1990-05-15"
+                                    },
+                                    "gender": {
+                                        "type": "string",
+                                        "example": "male"
+                                    },
+                                    "special_permissions": {
+                                        "type": "integer",
+                                        "example": 0
+                                    },
+                                    "can_report_abuse": {
+                                        "type": "integer",
+                                        "example": 0
+                                    },
+                                    "can_mobile_castration": {
+                                        "type": "integer",
+                                        "example": 0
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Cidadão atualizado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "example": "success"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "example": 200
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "uuid": {
+                                                    "type": "string",
+                                                    "example": "a3f4c9b2-1234-5678-9abc-9876543210ff"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "test@test.com"
+                                                },
+                                                "phone": {
+                                                    "type": "string",
+                                                    "example": "(31) 8730-5567"
+                                                },
+                                                "birth_date": {
+                                                    "type": "string",
+                                                    "format": "date",
+                                                    "example": "1990-05-15"
+                                                },
+                                                "gender": {
+                                                    "type": "string",
+                                                    "example": "male"
+                                                },
+                                                "special_permissions": {
+                                                    "type": "integer",
+                                                    "example": 0
+                                                },
+                                                "can_report_abuse": {
+                                                    "type": "integer",
+                                                    "example": 0
+                                                },
+                                                "can_mobile_castration": {
+                                                    "type": "integer",
+                                                    "example": 0
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "show": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/api/enums/{group}": {
             "get": {
                 "tags": [
@@ -1545,6 +2119,15 @@
             }
         }
     },
+    "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "bearerFormat": "JWT",
+                "scheme": "bearer"
+            }
+        }
+    },
     "tags": [
         {
             "name": "Auth",
@@ -1561,6 +2144,10 @@
         {
             "name": "Animals",
             "description": "Cadastro e controle de animais"
+        },
+        {
+            "name": "Citizens",
+            "description": "Gerenciamento de cidadãos"
         }
     ]
 }


### PR DESCRIPTION
# Descrição
## Adicionando criação e edição protetor

## O que foi feito
Implementação para permitir que administradores cadastrem protetores manualmente e editem as informações de protetores.

## Tipo de mudança
- [ ] Correção de bug.
- [X] Nova funcionalidade.
- [ ] Refatoração.
- [ ] Requer uma atualização na documentação.
- [ ] Contém migrate.
- [ ] Adição de novas dependências.
- [ ] Alteração da configuracão de ambiente local.
- [ ] Melhoria.

