### PR TITLE
Corrigir namespace e specialEnums para evitar 404

### DIFF
--- a/app/Http/Controllers/EnumController.php
+++ b/app/Http/Controllers/EnumController.php
@@ -8,16 +8,24 @@ use Illuminate\Support\Str;
 class EnumController extends Controller
 {
     public function show(Request $request, string $enum)
-    {
-        $locale = $request->get('locale', config('app.locale', 'en'));
-        $enumClass = 'App\\Domains\\Enums\\'.Str::studly($enum).'Enum';
+        {
+            $locale = $request->get('locale', config('app.locale', 'en'));
 
-        if (! enum_exists($enumClass)) {
-            return $this->error('Enum not found', [], 404);
+            $specialEnums = [
+                'uf' => 'UF',
+            ];
+
+           $enumClass = $specialEnums[strtolower($enum)] ?? Str::studly($enum);
+            
+            $enumClass = 'App\\Domains\\Enums\\'.$enumClass.'Enum';
+
+            if (! enum_exists($enumClass)) {
+                return $this->error('Enum not found', [], 404);
+            }
+
+            $data = ($enumClass)::labels($locale);
+
+            return $this->ok($data);
         }
 
-        $data = ($enumClass)::labels($locale);
-
-        return $this->ok($data);
-    }
 }


### PR DESCRIPTION
A rota `/api/enums/{enum}` estava retornando 404 para enums com UFEnum, 
mesmo quando a classe existia. Isso ocorria devido a Str::studly($enum) deixar com Uf e assim procurar por UfEnum

### Solução
- Agora o `enum_exists` consegue localizar a classe corretamente, 
  evitando 404 desnecessário.
- Mantido suporte a enums especiais (como 'uf') e enums padrões.

### Como testar
1. Chamar a rota `/api/enums/uf` e verificar se retorna corretamente os labels.
2. Testar outros enums padrões e verificar se continuam funcionando.